### PR TITLE
Change filetype to html.handlebars

### DIFF
--- a/ftdetect/handlebars.vim
+++ b/ftdetect/handlebars.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.hbs,*.handlebars setfiletype handlebars
+au BufNewFile,BufRead *.handlebars,*.hbs set filetype=html.handlebars syntax=handlebars


### PR DESCRIPTION
With this change, some tools can have a better understanding that handlebars are an extension of html. 

Tools like Onivim uses `html.*` to start a HTML language server, with this change now that works nicely.

Another point is that when using `vim-polyglot`, which includes vim-mustache-handlebars, it also sets the filetype as `html.handlebars` and now I can disable `handlebars` from `vim-polyglot` and this plugin will work.