### PR TITLE
feat: add support for angle bracket invocation of nested components

### DIFF
--- a/example.hbs
+++ b/example.hbs
@@ -10,6 +10,8 @@
 
 <HelloAngleBrackets @prop={{test}} />
 
+<AngleBrackets::-Components::Nested />
+
 <div class="my-css-class">{{test}}</div>
 
 {{#block-component property=@value  prop-erty=this.value string="testing"

--- a/syntax/handlebars.vim
+++ b/syntax/handlebars.vim
@@ -7,7 +7,7 @@ syntax cluster htmlPreproc add=hbsComponent,hbsMustache,hbsUnescaped,hbsMustache
 
 syntax match hbsEscapedMustache "\v\\\{\{"
 
-syntax region hbsComponent matchgroup=hbsComponentStatement start="\v\<(\/?)((\@\a+)|(\u\a+)|(\a+\.\a+))" end="\v\/?\>" keepend
+syntax region hbsComponent matchgroup=hbsComponentStatement start="\v\<(\/?)((\@\a+)|(((\w|-)+::)*\u\a+)|(\a+\.\a+))" end="\v\/?\>" keepend
 syntax region hbsMustache matchgroup=hbsHandles start="\v\{\{" skip="\v\\\}\}" end="\v\}\}" containedin=hbsComponent keepend
 syntax region hbsMustacheBlock matchgroup=hbsHandles start="\v\{\{[#/]" skip="\v\\\}\}" end="\v\}\}" keepend
 " modern hbs supports {{else <block>}} where <block> starts a new block


### PR DESCRIPTION
This adds support for properly highlighting angle bracket invocation of nested components, added in https://github.com/emberjs/rfcs/pull/457.