### PR TITLE
Ignore less-than sigil in strings

### DIFF
--- a/example.hbs
+++ b/example.hbs
@@ -1,6 +1,7 @@
 <AngleBraketComponent
   @mustache={{@bla}}
   @number=123
+  @string="example handles > sigil"
   data-test-id="test"
   class="my-class" as |test|>
   Some Text

--- a/syntax/handlebars.vim
+++ b/syntax/handlebars.vim
@@ -32,8 +32,8 @@ syntax match hbsBuiltInHelperInElse "\v(\{\{else\ )@<=<(component|with|if|each(\
 syntax match hbsKeyword "\v\s+as\s+" contained containedin=hbsComponent,hbsMustacheBlock,hbsElseBlock
 syntax region hbsStatement matchgroup=hbsDelimiter start="\v\|" end="\v\|" contained containedin=hbsComponent,hbsMustacheBlock,hbsElseBlock
 
-syntax region hbsString matchgroup=hbsString start=/\v\"/ skip=/\v\\\"/ end=/\v\"/ contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock
-syntax region hbsString matchgroup=hbsString start=/\v\'/ skip=/\v\\\'/ end=/\v\'/ contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock
+syntax region hbsString matchgroup=hbsString start=/\v\"/ skip=/\v\\\"/ end=/\v\"/ extend contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock
+syntax region hbsString matchgroup=hbsString start=/\v\'/ skip=/\v\\\'/ end=/\v\'/ extend contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock
 syntax match hbsNumber "\v<\d+>" contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock
 syntax match hbsArg "\v(\@\S+|\S+)\=@=" contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock
 syntax match hbsOperator "\v(\S+)@<=\=" contained containedin=hbsComponent,hbsMustache,hbsMustacheBlock,hbsPencil,hbsElseBlock


### PR DESCRIPTION
Prior to this change, adding a > character in a string would terminate the surrounding component highlighting.

This change adds the extend keyword to force Vim to ignore the keepend keyword for contained hbsString.

    :help syn-extend

Fixes #12